### PR TITLE
Bundle name in start-dev

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -171,7 +171,7 @@ module.exports = function(webpackEnv) {
               ? ''
               : `.${process.env.CI_PIPELINE_ID || '[chunkhash:8]'}`
           }.bundle.js`
-        : isEnvDevelopment && `${beameryConfig.filenamePrefix}.bundle.js`,
+        : isEnvDevelopment && `${beameryConfig.filenamePrefix}.[name].bundle.js`,
       // There are also additional JS chunk files if you use code splitting.
       /* chunkFilename: isEnvProduction
         ? `static/js/[name].[chunkhash:8].chunk.js`


### PR DESCRIPTION
Output `app-name.main.bundle.js` instead of `app-name.bundle.js`